### PR TITLE
Use a global mode for enabling highlighting

### DIFF
--- a/README.org
+++ b/README.org
@@ -28,13 +28,13 @@ Then, in your ~init.el~:
 
 ** Usage
 
-Use ~(eshell-syntax-highlighting-enable)~ to enable syntax highlighting in all future eshell sessions, and ~(eshell-syntax-highlighting-disable)~ to undo this.
+Use ~(eshell-syntax-highlighting-global-mode)~ to toggle highlighting in all future Eshell buffers.
 
-You can toggle highlighting in an existing session with ~(eshell-syntax-highlighting-mode)~.
+You can toggle highlighting in an existing buffer with ~(eshell-syntax-highlighting-mode)~.
 
 ** Customization
 
-Faces in this package inherit from standard faces to match your theming. If this results in ambiguous highlighting (e.g. your ~font-lock-function-name-face~ is red), or if you just want to customize the coloring,  you can use
+Faces in this package inherit from standard faces to match your theming. If this results in ambiguous highlighting (e.g. your ~font-lock-function-name-face~ is red), or if you just want to customize the coloring, you can use
 
     ~M-x customize-group eshell-syntax-highlighting~
 

--- a/README.org
+++ b/README.org
@@ -17,13 +17,13 @@ Then, in your ~init.el~:
 (add-to-list 'load-path "<path-to-eshell-syntax-highlighting-repository>")
 (require 'eshell-syntax-highlighting)
 ;; Use this to enable syntax highlighting by default
-(eshell-syntax-highlighting-enable)
+(eshell-syntax-highlighting-global-mode +1)
 
 ;; Alternatively, with use-package
 (use-package eshell-syntax-highlighting
   :after esh-mode
   :load-path "<path-to-eshell-syntax-highlighting-repository>"
-  :config (eshell-syntax-highlighting-enable))
+  :config (eshell-syntax-highlighting-global-mode +1))
 #+END_SRC
 
 ** Usage

--- a/eshell-syntax-highlighting.el
+++ b/eshell-syntax-highlighting.el
@@ -250,29 +250,28 @@
       (when (re-search-forward eshell-prompt-regexp (line-end-position) t)
         (eshell-syntax-highlighting--parse-and-highlight 'command)))))
 
-;;;###autoload
-(defun eshell-syntax-highlighting-enable ()
-  "Enable highlighting of Eshell commands in future sessions."
-  (interactive)
-  (add-hook 'eshell-mode-hook
-            #'eshell-syntax-highlighting-mode))
-
-(defun eshell-syntax-highlighting-disable ()
-  "Disable highlighting of Eshell commands in future sessions."
-  (interactive)
-  (remove-hook 'eshell-mode-hook
-               #'eshell-syntax-highlighting-mode))
 
 ;;;###autoload
 (define-minor-mode eshell-syntax-highlighting-mode
   "Toggle syntax highlighting for Eshell."
   nil nil nil
   (if (and eshell-syntax-highlighting-mode
-            (eq major-mode 'eshell-mode))
+           (eq major-mode 'eshell-mode)
+           (not eshell-non-interactive-p))
       (add-hook 'post-command-hook
                 #'eshell-syntax-highlighting--enable-highlighting nil t)
     (remove-hook 'post-command-hook
                  #'eshell-syntax-highlighting--enable-highlighting t)))
+
+;;;###autoload
+(define-globalized-minor-mode eshell-syntax-highlighting-global-mode
+  eshell-syntax-highlighting-mode eshell-syntax-highlighting--global-on)
+
+(defun eshell-syntax-highlighting--global-on ()
+    "Enable eshell-syntax-highlighting olny in appropriate buffers."
+    (when (and (eq major-mode 'eshell-mode)
+               (not eshell-non-interactive-p))
+      (eshell-syntax-highlighting-mode +1)))
 
 (provide 'eshell-syntax-highlighting)
 ;;; eshell-syntax-highlighting.el ends here


### PR DESCRIPTION
Instead of using custom enabling logic, this PR updates this package to use a global-mode.

This is a breaking change, as it remove `eshell-synatx-highlighting-enable/disable` for `eshell-syntax-highlighting-global-mode`.

The README is updated accordingly,