### PR TITLE
Better handling of tramp filenames with non-essential t

### DIFF
--- a/eshell-syntax-highlighting.el
+++ b/eshell-syntax-highlighting.el
@@ -283,7 +283,8 @@
   "Parse and highlight the command at the last Eshell prompt."
   (when (and (eq major-mode 'eshell-mode)
              (not eshell-non-interactive-p))
-    (let ((beg (point)))
+    (let ((beg (point))
+          (non-essential t))
       (save-excursion
         (goto-char eshell-last-output-end)
         (forward-line 0)


### PR DESCRIPTION
This addresses issues with highlighting trying to connect to remote sessions when validating file-names