### PR TITLE
Do highlighting silently to avoid changing undo data

### DIFF
--- a/eshell-syntax-highlighting.el
+++ b/eshell-syntax-highlighting.el
@@ -299,12 +299,13 @@
              (not mark-active))
     (let ((beg (point))
           (non-essential t))
-      (save-excursion
-        (goto-char eshell-last-output-end)
-        (forward-line 0)
-        (when (re-search-forward eshell-prompt-regexp (line-end-position) t)
-          (ignore-errors
-            (eshell-syntax-highlighting--parse-and-highlight 'command))))
+      (with-silent-modifications
+        (save-excursion
+          (goto-char eshell-last-output-end)
+          (forward-line 0)
+          (when (re-search-forward eshell-prompt-regexp (line-end-position) t)
+            (ignore-errors
+              (eshell-syntax-highlighting--parse-and-highlight 'command)))))
       ;; save-excursion marker is deleted when highlighting elisp,
       ;; so explicitly pop back to initial point.
       (goto-char beg))))


### PR DESCRIPTION
I noticed that I was unable to use undo and on some investigation it was due to the fact that undo data was full of syntax highlighting changes and I think since syntax-highlighting happens in the `post-command-hook` undoing it will just redo it again.
Wrapping with `with-silent-modifications` fixes that.